### PR TITLE
fixed error when getting prisoners by prison

### DIFF
--- a/routes/controllers/prisoner.controller.js
+++ b/routes/controllers/prisoner.controller.js
@@ -35,6 +35,7 @@ export default class PrisonerController extends RouteController {
         if (prison) {
             this.getListByPrison(req, res);
         }
+        else {
         try {
             const rules = await Prisoner.getAllPrisoners();
             this.#handleSuccess(res, rules);
@@ -42,7 +43,7 @@ export default class PrisonerController extends RouteController {
             err = !(err instanceof Error) ? new Error(err) : err;
             this.#handleErr(res, err);
         }
-
+    }
 
     }
 


### PR DESCRIPTION
Get prisoners by prison was crashing due to abselce of if-else in getMany, trying to run two hooks on the same response after it had already been sent out.

To test the error use the GET request
localhost:3000/prisoner/prisoners/?prison=1